### PR TITLE
feat: support ConfigMap-driven mock device declaration

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - name: Build
         run: go build -o ./k8s-device-plugin cmd/k8s-device-plugin/main.go
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -9,27 +9,41 @@ After deployment these resources show up under `node.status.allocatable` and `no
 
 ## How it works (read this first)
 
-The mock plugin **does not detect hardware**. It does the following every ~30s:
+The mock plugin **does not detect hardware**. It refreshes every ~30s and has two input paths:
 
 ```text
-  node annotation: hami.io/node-<vendor>-register = [ {devmem, devcore, ...}, ... ]   (1)
-  node capacity:   <count resource> (e.g. nvidia.com/gpu) > 0                          (2)  <- health gate
-                              | mock reads
-                              v
-  registers into allocatable: <vendor>/...mem , <vendor>/...cores , ...
+  recommended for NVIDIA:
+    ConfigMap file /mock-inventory/mock-inventory.yaml
+      -> groupBy.labelKey selects the node label
+      -> groups.<label-value>.nvidia[] becomes the active device list
+
+  legacy fallback:
+    node annotation: hami.io/node-<vendor>-register = [ {devmem, devcore, ...}, ... ]   (1)
+    node capacity:   <count resource> (e.g. nvidia.com/gpu) > 0                          (2)  <- health gate
+
+  active device list
+      -> registers into allocatable: <vendor>/...mem , <vendor>/...cores , ...
 ```
 
-On a **real** cluster, (1) and (2) are produced by the real device plugin. In a **mock-only** (no hardware) environment you provide them yourself:
+Today that means:
+
+- **NVIDIA primary path:** mount the optional `hami-mock-inventory` ConfigMap, label the node with `groupBy.labelKey`, and let the plugin read `groups.<group>.nvidia[]`.
+- **NVIDIA fallback path:** if the inventory file is missing, the node label is absent, or the label does not match a populated group, the plugin falls back to the legacy manual path.
+- **NVIDIA inventory errors:** malformed or otherwise unreadable inventory content is **not** a silent fallback case. The runtime surfaces the error, and `GetResource()` may fail fast until you fix the file or remove the inventory input.
+- **Ascend / Hygon:** these vendors still use the legacy manual path today.
+
+On a **real** cluster, the legacy annotation and count resource are normally produced by the real device plugin. In a **mock-only** (no hardware) environment you provide them yourself when using the fallback/manual path:
 
 - **(1) the `node-<vendor>-register` annotation** describing the fake cards -- `kubectl annotate`.
 - **(2) the count extended resource** (e.g. `nvidia.com/gpu`) -- patched onto the node `status`.
 
-> There is **no auto-labeller** in this repo, so (1) and (2) are manual today. Forgetting them is the usual cause of `device xxx is unhealthy` / `no allocation` -- see issues #14 / #16.
+> Inventory updates are **not instant**. ConfigMap-to-file propagation is kubelet-driven (commonly up to about 1 minute), and the mock plugin only refreshes every 30s, so end-to-end visibility can lag by up to roughly **90 seconds** after you change the ConfigMap or node label.
 
 ## Prerequisites
 
 - Kubernetes >= v1.18
 - The `hami-scheduler-device` ConfigMap (the device config). If HAMi is installed it already exists; otherwise create it from [device-configmap.yaml](https://github.com/Project-HAMi/HAMi/blob/master/charts/hami/templates/scheduler/device-configmap.yaml).
+- Optional but recommended for NVIDIA: a `hami-mock-inventory` ConfigMap containing `mock-inventory.yaml`. The shipped DaemonSet mounts it as an optional directory, so the plugin can still start and fall back to the legacy path when the ConfigMap is absent.
 
 ## Deployment
 
@@ -42,14 +56,18 @@ kubectl apply -f k8s-mock-plugin.yaml
 
 ## Understanding the values
 
-The mock **derives the registered resources from the annotation, not from the count resource.** This trips people up, so to be explicit:
+The mock **derives the registered resources from the active device list, not from the count resource.** This trips people up, so to be explicit:
 
-- **Number of fake cards = the number of entries in the annotation array** (not the count value).
+- For **NVIDIA on the recommended path**, the active device list is `groups.<matched-node-group>.nvidia[]` from `mock-inventory.yaml`.
+- For **legacy/manual mode** (including Ascend and Hygon), the active device list is the `node-<vendor>-register` annotation.
+
+- **Number of fake cards = the number of entries in the active device list** (not the count value).
 - Registered `...-memory` = **sum of `devmem`** over all entries.
 - Registered `...-cores` / `...-core` = **sum of `devcore`** over all entries.
-- The **count extended resource is only a health gate**: its value just needs to be `> 0`. It does **not** affect the registered memory/cores. By convention it is set to `cards x splits-per-card` (e.g. Ascend `2 x VDeviceCount(4) = 8`), but `1` would work equally well for the memory/cores to appear.
+- On the **legacy/manual path**, the count extended resource is only a health gate: its value just needs to be `> 0`. It does **not** affect the registered memory/cores. By convention it is set to `cards x splits-per-card` (e.g. Ascend `2 x VDeviceCount(4) = 8`), but `1` would work equally well for the memory/cores to appear.
+- On the **NVIDIA inventory-active path**, the plugin returns file-backed resources directly and bypasses that legacy health-gate check. Keep the `nvidia.com/gpu` patch in your mock setup because operators typically still want the vendor count resource present on the node, but it is not what drives the inventory-backed `gpumem` / `gpucores` totals.
 
-Annotation entry fields:
+Device entry fields:
 
 | field | meaning |
 | :-- | :-- |
@@ -66,12 +84,54 @@ Annotation entry fields:
 
 ## Usage by vendor
 
-To mock one card you always need the **three pieces**: the vendor **config block** (in the `hami-scheduler-device` ConfigMap, gives the resource names), the **count extended resource** (passes the health gate), and the **node-register annotation** (describes the fake cards). Replace `<node>` below with your target node. Resource names follow the ConfigMap (HAMi defaults shown). See [Understanding the values](#understanding-the-values) for how the numbers are derived.
+To mock one card you always need the vendor **config block** (in the `hami-scheduler-device` ConfigMap, gives the resource names) plus an **active device list** that describes the fake cards. For NVIDIA the active list can come from the recommended ConfigMap inventory or the legacy node annotation; for Ascend and Hygon it still comes from the node annotation. In most end-to-end mock setups you will also patch the vendor **count extended resource** onto the node. On the legacy/manual path that count resource is the health gate; on the NVIDIA inventory-active path it is still commonly present on the node, but it is not what drives the inventory-backed resource totals. Replace `<node>` below with your target node. Resource names follow the ConfigMap (HAMi defaults shown). See [Understanding the values](#understanding-the-values) for how the numbers are derived.
 
 ### NVIDIA (e.g. A100-80GB)
 
 - config block: `nvidia:` | annotation: `hami.io/node-nvidia-register` (JSON) | count: `nvidia.com/gpu`
 - mock registers: `nvidia.com/gpumem`, `nvidia.com/gpucores`, `nvidia.com/gpumem-percentage`
+
+#### Recommended: ConfigMap + node-group label
+
+Create a file-backed inventory, label the node into one of its groups, and keep the `nvidia.com/gpu` patch in place as part of the overall mock node setup:
+
+```bash
+cat > mock-inventory.yaml <<'EOF'
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy:
+  labelKey: hami.io/mock-group
+groups:
+  gpu-a100:
+    nvidia:
+      - id: GPU-MOCK-0
+        index: 0
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: 81920
+        devcore: 100
+        count: 10
+        health: true
+EOF
+
+kubectl -n kube-system create configmap hami-mock-inventory \
+  --from-file=mock-inventory.yaml=./mock-inventory.yaml \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl label node <node> hami.io/mock-group=gpu-a100 --overwrite
+
+kubectl patch node <node> --subresource=status --type=json \
+  -p '[{"op":"add","path":"/status/capacity/nvidia.com~1gpu","value":"10"}]'
+
+# verify after ConfigMap sync + plugin refresh (allow up to ~90s)
+kubectl get node <node> -o json | jq '.status.allocatable|with_entries(select(.key|test("nvidia.com")))'
+# expect: nvidia.com/gpu=10, nvidia.com/gpumem=81920, nvidia.com/gpucores=100, nvidia.com/gpumem-percentage=100
+```
+
+If the ConfigMap/file is missing, the node label is absent, or the label does not match a populated group, the plugin falls back to the legacy annotation path below.
+
+If the inventory file exists but is malformed or otherwise unreadable, that is not a silent fallback case. Fix the file contents or remove the inventory input so the plugin can resume normal operation.
+
+#### Legacy fallback: manual annotation
 
 ```bash
 # (2) count resource: splitCount=10 -> one card advertises 10

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Today that means:
 
 - **NVIDIA primary path:** mount the optional `hami-mock-inventory` ConfigMap, label the node with `groupBy.labelKey`, and let the plugin read `groups.<group>.nvidia[]`.
 - **NVIDIA fallback path:** if the inventory file is missing, the node label is absent, or the label does not match a populated group, the plugin falls back to the legacy manual path.
-- **NVIDIA inventory errors:** malformed or otherwise unreadable inventory content is **not** a silent fallback case. The runtime surfaces the error, and `GetResource()` may fail fast until you fix the file or remove the inventory input.
+- **NVIDIA inventory errors:** if the current node matches a group and that group's NVIDIA inventory is malformed or unreadable, the runtime surfaces the error instead of silently falling back.
 - **Ascend / Hygon:** these vendors still use the legacy manual path today.
 
 On a **real** cluster, the legacy annotation and count resource are normally produced by the real device plugin. In a **mock-only** (no hardware) environment you provide them yourself when using the fallback/manual path:
@@ -77,7 +77,7 @@ Device entry fields:
 | `count` | per-card split count (informational for the mock) |
 | `type` | device model string |
 | `health` | must be `true` to be counted |
-| `index` | card index `0,1,2,...` (`0` may be omitted) |
+| `index` | card index `0,1,2,...`; required for inventory-backed entries, optional on the legacy/manual annotation path (defaults to `0` if omitted) |
 | `numa`, `mode` | optional |
 
 > **Worked example (Ascend, below):** the annotation has **2 entries**, each `devmem=32768`. So `...-memory = 2x32768 = 65536` and `...-core = 2x100 = 200` (Ascend `...-core` is **percentage-based**: a whole card is always **100**). The count resource `=8` is a separate health-gate value and is unrelated to these numbers.
@@ -129,7 +129,7 @@ kubectl get node <node> -o json | jq '.status.allocatable|with_entries(select(.k
 
 If the ConfigMap/file is missing, the node label is absent, or the label does not match a populated group, the plugin falls back to the legacy annotation path below.
 
-If the inventory file exists but is malformed or otherwise unreadable, that is not a silent fallback case. Fix the file contents or remove the inventory input so the plugin can resume normal operation.
+If the current node matches a group whose NVIDIA inventory is malformed or otherwise unreadable, that is not a silent fallback case. Fix that matched group or remove the inventory input so the plugin can resume normal operation.
 
 #### Legacy fallback: manual annotation
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ The mock plugin **does not detect hardware**. It refreshes every ~30s and has tw
 Today that means:
 
 - **NVIDIA primary path:** mount the optional `hami-mock-inventory` ConfigMap, label the node with `groupBy.labelKey`, and let the plugin read `groups.<group>.nvidia[]`.
-- **NVIDIA fallback path:** if the inventory file is missing, the node label is absent, or the label does not match a populated group, the plugin falls back to the legacy manual path.
-- **NVIDIA inventory errors:** if the current node matches a group and that group's NVIDIA inventory is malformed or unreadable, the runtime surfaces the error instead of silently falling back.
+- **Fallback behavior:** if the inventory file is missing, the node label is absent, or the label does not match a populated group, the plugin falls back to the legacy manual path.
+- **Malformed inventory behavior:** if the current node matches a group and that group's NVIDIA inventory is malformed or unreadable, the runtime surfaces the error instead of silently falling back.
 - **Ascend / Hygon:** these vendors still use the legacy manual path today.
 
 On a **real** cluster, the legacy annotation and count resource are normally produced by the real device plugin. In a **mock-only** (no hardware) environment you provide them yourself when using the fallback/manual path:

--- a/internal/pkg/api/device/device.go
+++ b/internal/pkg/api/device/device.go
@@ -146,6 +146,45 @@ func UnMarshalNodeDevices(str string) ([]*DeviceInfo, error) {
 	return dlist, err
 }
 
+// MarshalNodeDevices normalizes the scheduler-facing node-register annotation to
+// the general device fields HAMi already consumes from JSON.
+func MarshalNodeDevices(dlist []*DeviceInfo) string {
+	type nodeDeviceAnnotation struct {
+		ID      string `json:"id,omitempty"`
+		Index   uint   `json:"index,omitempty"`
+		Count   int32  `json:"count,omitempty"`
+		Devmem  int32  `json:"devmem,omitempty"`
+		Devcore int32  `json:"devcore,omitempty"`
+		Type    string `json:"type,omitempty"`
+		Numa    int    `json:"numa,omitempty"`
+		Mode    string `json:"mode,omitempty"`
+		Health  bool   `json:"health,omitempty"`
+	}
+
+	devAnnos := make([]*nodeDeviceAnnotation, 0, len(dlist))
+	for _, val := range dlist {
+		if val == nil {
+			continue
+		}
+		devAnnos = append(devAnnos, &nodeDeviceAnnotation{
+			ID:      val.ID,
+			Count:   val.Count,
+			Devmem:  val.Devmem,
+			Devcore: val.Devcore,
+			Type:    val.Type,
+			Numa:    val.Numa,
+			Health:  val.Health,
+			Index:   val.Index,
+			Mode:    val.Mode,
+		})
+	}
+	data, err := json.Marshal(devAnnos)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
 func DecodeNodeDevices(str string) ([]*DeviceInfo, error) {
 	if !strings.Contains(str, OneContainerMultiDeviceSplitSymbol) {
 		return []*DeviceInfo{}, errors.New("node annotations not decode successfully")

--- a/internal/pkg/api/device/device.go
+++ b/internal/pkg/api/device/device.go
@@ -151,12 +151,12 @@ func UnMarshalNodeDevices(str string) ([]*DeviceInfo, error) {
 func MarshalNodeDevices(dlist []*DeviceInfo) string {
 	type nodeDeviceAnnotation struct {
 		ID      string `json:"id,omitempty"`
-		Index   uint   `json:"index,omitempty"`
-		Count   int32  `json:"count,omitempty"`
-		Devmem  int32  `json:"devmem,omitempty"`
-		Devcore int32  `json:"devcore,omitempty"`
+		Index   uint   `json:"index"`
+		Count   int32  `json:"count"`
+		Devmem  int32  `json:"devmem"`
+		Devcore int32  `json:"devcore"`
 		Type    string `json:"type,omitempty"`
-		Numa    int    `json:"numa,omitempty"`
+		Numa    int    `json:"numa"`
 		Mode    string `json:"mode,omitempty"`
 		Health  bool   `json:"health,omitempty"`
 	}

--- a/internal/pkg/api/device/device_test.go
+++ b/internal/pkg/api/device/device_test.go
@@ -135,6 +135,17 @@ func TestMarshalNodeDevices(t *testing.T) {
 				},
 			},
 		},
+		{
+			ID:      "GPU-1",
+			Index:   0,
+			Count:   1,
+			Devmem:  1024,
+			Devcore: 0,
+			Type:    "NVIDIA-Zero-Value",
+			Numa:    0,
+			Mode:    "hami-core",
+			Health:  true,
+		},
 	}
 
 	marshaled := MarshalNodeDevices(input)
@@ -149,6 +160,15 @@ func TestMarshalNodeDevices(t *testing.T) {
 	}
 	if strings.Contains(marshaled, "migtemplate") {
 		t.Fatalf("expected migtemplate to be omitted, got %s", marshaled)
+	}
+	if !strings.Contains(marshaled, `"index":0`) {
+		t.Fatalf("expected zero-valued index to be serialized, got %s", marshaled)
+	}
+	if !strings.Contains(marshaled, `"numa":0`) {
+		t.Fatalf("expected zero-valued numa to be serialized, got %s", marshaled)
+	}
+	if !strings.Contains(marshaled, `"devcore":0`) {
+		t.Fatalf("expected zero-valued devcore to be serialized, got %s", marshaled)
 	}
 
 	got, err := UnMarshalNodeDevices(marshaled)
@@ -165,6 +185,17 @@ func TestMarshalNodeDevices(t *testing.T) {
 			Devcore: 50,
 			Type:    "NVIDIA-Legacy",
 			Numa:    1,
+			Mode:    "hami-core",
+			Health:  true,
+		},
+		{
+			ID:      "GPU-1",
+			Index:   0,
+			Count:   1,
+			Devmem:  1024,
+			Devcore: 0,
+			Type:    "NVIDIA-Zero-Value",
+			Numa:    0,
 			Mode:    "hami-core",
 			Health:  true,
 		},

--- a/internal/pkg/api/device/device_test.go
+++ b/internal/pkg/api/device/device_test.go
@@ -18,6 +18,7 @@ package device
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -100,4 +101,73 @@ func Test_DecodeNodeDevices(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMarshalNodeDevices(t *testing.T) {
+	input := []*DeviceInfo{
+		{
+			ID:           "GPU-0",
+			Index:        1,
+			Count:        10,
+			Devmem:       40960,
+			Devcore:      50,
+			Type:         "NVIDIA-Legacy",
+			Numa:         1,
+			Mode:         "hami-core",
+			Health:       true,
+			DeviceVendor: "NVIDIA",
+			CustomInfo: map[string]any{
+				"ignored": "value",
+			},
+			DevicePairScore: DevicePairScore{
+				ID: "GPU-0",
+				Scores: map[string]int{
+					"GPU-1": 100,
+				},
+			},
+			MIGTemplate: []Geometry{
+				{
+					{
+						Name:   "1g.10gb",
+						Memory: 10,
+						Count:  1,
+					},
+				},
+			},
+		},
+	}
+
+	marshaled := MarshalNodeDevices(input)
+	if strings.Contains(marshaled, "custominfo") {
+		t.Fatalf("expected custominfo to be omitted, got %s", marshaled)
+	}
+	if strings.Contains(marshaled, "devicevendor") {
+		t.Fatalf("expected devicevendor to be omitted, got %s", marshaled)
+	}
+	if strings.Contains(marshaled, "devicepairscore") {
+		t.Fatalf("expected devicepairscore to be omitted, got %s", marshaled)
+	}
+	if strings.Contains(marshaled, "migtemplate") {
+		t.Fatalf("expected migtemplate to be omitted, got %s", marshaled)
+	}
+
+	got, err := UnMarshalNodeDevices(marshaled)
+	if err != nil {
+		t.Fatalf("UnMarshalNodeDevices() error = %v", err)
+	}
+
+	expected := []*DeviceInfo{
+		{
+			ID:      "GPU-0",
+			Index:   1,
+			Count:   10,
+			Devmem:  40960,
+			Devcore: 50,
+			Type:    "NVIDIA-Legacy",
+			Numa:    1,
+			Mode:    "hami-core",
+			Health:  true,
+		},
+	}
+	assert.DeepEqual(t, expected, got)
 }

--- a/internal/pkg/api/device/nvidia/device.go
+++ b/internal/pkg/api/device/nvidia/device.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nvidia
 
 import (
+	"context"
 	"errors"
 	"os"
 	"strings"
@@ -24,9 +25,11 @@ import (
 	"github.com/HAMi/mock-device-plugin/internal/pkg/api/device"
 	"github.com/HAMi/mock-device-plugin/internal/pkg/mock"
 	"github.com/HAMi/mock-device-plugin/internal/pkg/mockinventory"
+	"github.com/HAMi/mock-device-plugin/internal/pkg/util/client"
 	"github.com/kubevirt/device-plugin-manager/pkg/dpm"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 )
 
@@ -106,6 +109,16 @@ type NvidiaGPUDevices struct {
 	config            NvidiaConfig
 	mockInventoryFile string
 	ReportedGPUNum    int64
+}
+
+var updateNodeRegisterAnnotation = func(ctx context.Context, node *corev1.Node, annotation string) error {
+	updated := node.DeepCopy()
+	if updated.Annotations == nil {
+		updated.Annotations = map[string]string{}
+	}
+	updated.Annotations[RegisterAnnos] = annotation
+	_, err := client.GetClient().CoreV1().Nodes().Update(ctx, updated, metav1.UpdateOptions{})
+	return err
 }
 
 func InitNvidiaDevice(nvconfig NvidiaConfig, mockInventoryFile string) *NvidiaGPUDevices {
@@ -271,6 +284,30 @@ func (dev *NvidiaGPUDevices) sumResources(devs []*device.DeviceInfo) map[string]
 	return resourceMap
 }
 
+func (dev *NvidiaGPUDevices) syncInventoryAnnotation(n *corev1.Node, devs []*device.DeviceInfo) error {
+	desired := device.MarshalNodeDevices(devs)
+	if desired == "" {
+		return errors.New("marshal inventory-backed devices for node annotation")
+	}
+
+	current := ""
+	if n.Annotations != nil {
+		current = n.Annotations[RegisterAnnos]
+	}
+	if current == desired {
+		return nil
+	}
+
+	if err := updateNodeRegisterAnnotation(context.Background(), n, desired); err != nil {
+		return err
+	}
+	if n.Annotations == nil {
+		n.Annotations = map[string]string{}
+	}
+	n.Annotations[RegisterAnnos] = desired
+	return nil
+}
+
 func (dev *NvidiaGPUDevices) GetResource(n *corev1.Node) map[string]int {
 	resourceMap := dev.emptyResourceMap()
 
@@ -284,6 +321,10 @@ func (dev *NvidiaGPUDevices) GetResource(n *corev1.Node) map[string]int {
 		return resourceMap
 	}
 	if active {
+		if err := dev.syncInventoryAnnotation(n, devs); err != nil {
+			klog.ErrorS(err, "failed to sync inventory-backed node register annotation", "node", n.Name, "annotation", RegisterAnnos)
+			return resourceMap
+		}
 		return dev.sumResources(devs)
 	}
 

--- a/internal/pkg/api/device/nvidia/device.go
+++ b/internal/pkg/api/device/nvidia/device.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/HAMi/mock-device-plugin/internal/pkg/api/device"
 	"github.com/HAMi/mock-device-plugin/internal/pkg/mock"
@@ -64,6 +65,7 @@ const (
 	NvidiaGPUCommonWord  = "GPU"
 	Vendor               = "nvidia.com"
 	MigMode              = "mig"
+	inventoryAnnotationSyncTimeout = 5 * time.Second
 )
 
 type LibCudaLogLevel string
@@ -298,7 +300,10 @@ func (dev *NvidiaGPUDevices) syncInventoryAnnotation(n *corev1.Node, devs []*dev
 		return nil
 	}
 
-	if err := updateNodeRegisterAnnotation(context.Background(), n, desired); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), inventoryAnnotationSyncTimeout)
+	defer cancel()
+
+	if err := updateNodeRegisterAnnotation(ctx, n, desired); err != nil {
 		return err
 	}
 	if n.Annotations == nil {

--- a/internal/pkg/api/device/nvidia/device.go
+++ b/internal/pkg/api/device/nvidia/device.go
@@ -18,10 +18,12 @@ package nvidia
 
 import (
 	"errors"
+	"os"
 	"strings"
 
 	"github.com/HAMi/mock-device-plugin/internal/pkg/api/device"
 	"github.com/HAMi/mock-device-plugin/internal/pkg/mock"
+	"github.com/HAMi/mock-device-plugin/internal/pkg/mockinventory"
 	"github.com/kubevirt/device-plugin-manager/pkg/dpm"
 
 	corev1 "k8s.io/api/core/v1"
@@ -77,15 +79,17 @@ type NodeDefaultConfig struct {
 }
 
 type NvidiaGPUDevices struct {
-	config         NvidiaConfig
-	ReportedGPUNum int64
+	config            NvidiaConfig
+	mockInventoryFile string
+	ReportedGPUNum    int64
 }
 
-func InitNvidiaDevice(nvconfig NvidiaConfig) *NvidiaGPUDevices {
+func InitNvidiaDevice(nvconfig NvidiaConfig, mockInventoryFile string) *NvidiaGPUDevices {
 	klog.InfoS("initializing nvidia device", "resourceName", nvconfig.ResourceCountName, "resourceMem", nvconfig.ResourceMemoryName, "DefaultGPUNum", nvconfig.DefaultGPUNum)
 	return &NvidiaGPUDevices{
-		config:         nvconfig,
-		ReportedGPUNum: 0,
+		config:            nvconfig,
+		mockInventoryFile: mockInventoryFile,
+		ReportedGPUNum:    0,
 	}
 }
 
@@ -93,22 +97,9 @@ func (dev *NvidiaGPUDevices) CommonWord() string {
 	return NvidiaGPUDevice
 }
 
-func (dev *NvidiaGPUDevices) GetNodeDevices(n *corev1.Node) ([]*device.DeviceInfo, error) {
-	devEncoded, ok := n.Annotations[RegisterAnnos]
-	if !ok {
-		return []*device.DeviceInfo{}, errors.New("annos not found " + RegisterAnnos)
-	}
-	nodedevices, err := device.UnMarshalNodeDevices(devEncoded)
-	if err != nil {
-		klog.Infof("decode error. try to decode with old method. error %s", err.Error())
-		nodedevices, err = device.DecodeNodeDevices(devEncoded)
-		if err != nil {
-			klog.ErrorS(err, "failed to decode node devices", "node", n.Name, "device annotation", devEncoded)
-			return []*device.DeviceInfo{}, err
-		}
-	}
+func (dev *NvidiaGPUDevices) decorateDevices(n *corev1.Node, nodedevices []*device.DeviceInfo) ([]*device.DeviceInfo, error) {
 	if len(nodedevices) == 0 {
-		klog.InfoS("no nvidia gpu device found", "node", n.Name, "device annotation", devEncoded)
+		klog.InfoS("no nvidia gpu device found", "node", n.Name)
 		return []*device.DeviceInfo{}, errors.New("no gpu found on node")
 	}
 	for idx := range nodedevices {
@@ -161,24 +152,76 @@ func (dev *NvidiaGPUDevices) GetNodeDevices(n *corev1.Node) ([]*device.DeviceInf
 	return nodedevices, nil
 }
 
-func (dev *NvidiaGPUDevices) GetResource(n *corev1.Node) map[string]int {
+func (dev *NvidiaGPUDevices) getAnnotationDevices(n *corev1.Node) ([]*device.DeviceInfo, error) {
+	devEncoded, ok := n.Annotations[RegisterAnnos]
+	if !ok {
+		return []*device.DeviceInfo{}, errors.New("annos not found " + RegisterAnnos)
+	}
+	nodedevices, err := device.UnMarshalNodeDevices(devEncoded)
+	if err != nil {
+		klog.Infof("decode error. try to decode with old method. error %s", err.Error())
+		nodedevices, err = device.DecodeNodeDevices(devEncoded)
+		if err != nil {
+			klog.ErrorS(err, "failed to decode node devices", "node", n.Name, "device annotation", devEncoded)
+			return []*device.DeviceInfo{}, err
+		}
+	}
+
+	return dev.decorateDevices(n, nodedevices)
+}
+
+func (dev *NvidiaGPUDevices) getInventoryDevices(n *corev1.Node) ([]*device.DeviceInfo, bool, error) {
+	if dev.mockInventoryFile == "" {
+		return nil, false, nil
+	}
+
+	inv, err := mockinventory.Load(dev.mockInventoryFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+
+	nodedevices, active, err := inv.ResolveNvidiaDevices(n)
+	if err != nil || !active {
+		return nil, active, err
+	}
+
+	decorated, err := dev.decorateDevices(n, nodedevices)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return decorated, true, nil
+}
+
+func (dev *NvidiaGPUDevices) GetNodeDevices(n *corev1.Node) ([]*device.DeviceInfo, error) {
+	nodedevices, active, err := dev.getInventoryDevices(n)
+	if err != nil {
+		return []*device.DeviceInfo{}, err
+	}
+	if active {
+		return nodedevices, nil
+	}
+
+	return dev.getAnnotationDevices(n)
+}
+
+func (dev *NvidiaGPUDevices) emptyResourceMap() map[string]int {
+	return map[string]int{
+		device.GetResourceName(dev.config.ResourceMemoryName):           0,
+		device.GetResourceName(dev.config.ResourceCoreName):             0,
+		device.GetResourceName(dev.config.ResourceMemoryPercentageName): 0,
+	}
+}
+
+func (dev *NvidiaGPUDevices) sumResources(devs []*device.DeviceInfo) map[string]int {
+	resourceMap := dev.emptyResourceMap()
 	memoryResourceName := device.GetResourceName(dev.config.ResourceMemoryName)
 	coreResourceName := device.GetResourceName(dev.config.ResourceCoreName)
 	memoryPercentageName := device.GetResourceName(dev.config.ResourceMemoryPercentageName)
-	resourceMap := map[string]int{
-		memoryResourceName:   0,
-		coreResourceName:     0,
-		memoryPercentageName: 0,
-	}
-	if !device.CheckHealthy(n, dev.config.ResourceCountName) {
-		klog.Infof("device %s is unhealthy on this node", dev.CommonWord())
-		return resourceMap
-	}
-	devs, err := dev.GetNodeDevices(n)
-	if err != nil {
-		klog.Infof("no device %s on this node", NvidiaGPUCommonWord)
-		return resourceMap
-	}
+
 	for _, val := range devs {
 		resourceMap[memoryResourceName] += int(val.Devmem)
 		resourceMap[coreResourceName] += int(val.Devcore)
@@ -197,7 +240,32 @@ func (dev *NvidiaGPUDevices) GetResource(n *corev1.Node) map[string]int {
 		memoryPercentageName,
 		resourceMap[memoryPercentageName],
 	)
+
 	return resourceMap
+}
+
+func (dev *NvidiaGPUDevices) GetResource(n *corev1.Node) map[string]int {
+	resourceMap := dev.emptyResourceMap()
+
+	devs, active, err := dev.getInventoryDevices(n)
+	if err != nil {
+		klog.Fatalf("failed to load mock inventory for node %s: %v", n.Name, err)
+	}
+	if active {
+		return dev.sumResources(devs)
+	}
+
+	if !device.CheckHealthy(n, dev.config.ResourceCountName) {
+		klog.Infof("device %s is unhealthy on this node", dev.CommonWord())
+		return resourceMap
+	}
+	devs, err = dev.getAnnotationDevices(n)
+	if err != nil {
+		klog.Infof("no device %s on this node", NvidiaGPUCommonWord)
+		return resourceMap
+	}
+
+	return dev.sumResources(devs)
 }
 
 func (dev *NvidiaGPUDevices) RunManager() {

--- a/internal/pkg/api/device/nvidia/device.go
+++ b/internal/pkg/api/device/nvidia/device.go
@@ -30,6 +30,30 @@ import (
 	"k8s.io/klog/v2"
 )
 
+type inventoryConfigError struct {
+	err error
+}
+
+func (e *inventoryConfigError) Error() string {
+	return e.err.Error()
+}
+
+func (e *inventoryConfigError) Unwrap() error {
+	return e.err
+}
+
+type inventoryDecorationError struct {
+	err error
+}
+
+func (e *inventoryDecorationError) Error() string {
+	return e.err.Error()
+}
+
+func (e *inventoryDecorationError) Unwrap() error {
+	return e.err
+}
+
 const (
 	RegisterAnnos        = "hami.io/node-nvidia-register"
 	RegisterGPUPairScore = "hami.io/node-nvidia-score"
@@ -180,17 +204,20 @@ func (dev *NvidiaGPUDevices) getInventoryDevices(n *corev1.Node) ([]*device.Devi
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, false, nil
 		}
-		return nil, false, err
+		return nil, false, &inventoryConfigError{err: err}
 	}
 
 	nodedevices, active, err := inv.ResolveNvidiaDevices(n)
-	if err != nil || !active {
-		return nil, active, err
+	if err != nil {
+		return nil, active, &inventoryConfigError{err: err}
+	}
+	if !active {
+		return nil, false, nil
 	}
 
 	decorated, err := dev.decorateDevices(n, nodedevices)
 	if err != nil {
-		return nil, false, err
+		return nil, true, &inventoryDecorationError{err: err}
 	}
 
 	return decorated, true, nil
@@ -249,7 +276,12 @@ func (dev *NvidiaGPUDevices) GetResource(n *corev1.Node) map[string]int {
 
 	devs, active, err := dev.getInventoryDevices(n)
 	if err != nil {
-		klog.Fatalf("failed to load mock inventory for node %s: %v", n.Name, err)
+		var configErr *inventoryConfigError
+		if errors.As(err, &configErr) {
+			klog.Fatalf("failed to resolve mock inventory for node %s: %v", n.Name, err)
+		}
+		klog.ErrorS(err, "failed to decorate inventory-backed devices", "node", n.Name)
+		return resourceMap
 	}
 	if active {
 		return dev.sumResources(devs)

--- a/internal/pkg/api/device/nvidia/device_test.go
+++ b/internal/pkg/api/device/nvidia/device_test.go
@@ -248,6 +248,54 @@ groups:
 	}
 }
 
+func TestGetResourceSkipsInventoryNodeWhenPairScoreAnnotationMalformed(t *testing.T) {
+	inventoryPath := writeInventoryFile(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy:
+  labelKey: hami.io/mock-group
+groups:
+  gpu-a100:
+    nvidia:
+      - id: GPU-MOCK-0
+        index: 0
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: 81920
+        devcore: 100
+        count: 10
+        health: true
+`)
+
+	config := NvidiaConfig{
+		ResourceCountName:            "nvidia.com/gpu",
+		ResourceMemoryName:           "nvidia.com/gpu-memory",
+		ResourceCoreName:             "nvidia.com/gpu-core",
+		ResourceMemoryPercentageName: "nvidia.com/gpu-memory-percentage",
+	}
+	dev := InitNvidiaDevice(config, inventoryPath)
+
+	node := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-a100-0",
+			Labels: map[string]string{"hami.io/mock-group": "gpu-a100"},
+			Annotations: map[string]string{
+				RegisterGPUPairScore: "not-json",
+			},
+		},
+	}
+
+	got := dev.GetResource(&node)
+	if got["gpu-memory"] != 0 {
+		t.Fatalf("expected malformed pair-score annotation to skip inventory resources, got memory %d", got["gpu-memory"])
+	}
+	if got["gpu-core"] != 0 {
+		t.Fatalf("expected malformed pair-score annotation to skip inventory resources, got core %d", got["gpu-core"])
+	}
+	if got["gpu-memory-percentage"] != 0 {
+		t.Fatalf("expected malformed pair-score annotation to skip inventory resources, got memory percentage %d", got["gpu-memory-percentage"])
+	}
+}
+
 func TestGetNodeDevices(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -392,5 +440,40 @@ groups:
 	_, err := dev.GetNodeDevices(&node)
 	if err == nil {
 		t.Fatalf("expected invalid inventory to return an error")
+	}
+}
+
+func TestGetNodeDevicesReturnsPairScoreErrorForInventoryNode(t *testing.T) {
+	inventoryPath := writeInventoryFile(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy:
+  labelKey: hami.io/mock-group
+groups:
+  gpu-a100:
+    nvidia:
+      - id: GPU-MOCK-0
+        index: 0
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: 81920
+        devcore: 100
+        count: 10
+        health: true
+`)
+
+	dev := InitNvidiaDevice(NvidiaConfig{}, inventoryPath)
+	node := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-a100-0",
+			Labels: map[string]string{"hami.io/mock-group": "gpu-a100"},
+			Annotations: map[string]string{
+				RegisterGPUPairScore: "not-json",
+			},
+		},
+	}
+
+	_, err := dev.GetNodeDevices(&node)
+	if err == nil {
+		t.Fatalf("expected malformed pair-score annotation to return an error")
 	}
 }

--- a/internal/pkg/api/device/nvidia/device_test.go
+++ b/internal/pkg/api/device/nvidia/device_test.go
@@ -154,10 +154,56 @@ kind: MockInventory
 groupBy:
   labelKey: hami.io/mock-group
 groups:
+  gpu-a100: {}
+`)
+
+	config := NvidiaConfig{
+		ResourceCountName:            "nvidia.com/gpu",
+		ResourceMemoryName:           "nvidia.com/gpu-memory",
+		ResourceCoreName:             "nvidia.com/gpu-core",
+		ResourceMemoryPercentageName: "nvidia.com/gpu-memory-percentage",
+	}
+	dev := InitNvidiaDevice(config, inventoryPath)
+
+	node := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-legacy",
+			Labels: map[string]string{
+				"hami.io/mock-group": "gpu-a100",
+			},
+			Annotations: map[string]string{
+				RegisterAnnos: `[{"id":"GPU-0","index":0,"count":10,"devmem":40960,"devcore":50,"type":"NVIDIA-Legacy","health":true}]`,
+			},
+		},
+		Status: corev1.NodeStatus{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceName(config.ResourceCountName): resource.MustParse("1"),
+			},
+		},
+	}
+
+	got := dev.GetResource(&node)
+	if got["gpu-memory"] != 40960 {
+		t.Fatalf("expected annotation fallback memory 40960, got %d", got["gpu-memory"])
+	}
+	if got["gpu-core"] != 50 {
+		t.Fatalf("expected annotation fallback core 50, got %d", got["gpu-core"])
+	}
+	if got["gpu-memory-percentage"] != 100 {
+		t.Fatalf("expected annotation fallback memory percentage 100, got %d", got["gpu-memory-percentage"])
+	}
+}
+
+func TestGetResourceFallsBackWhenOtherInventoryGroupIsInvalid(t *testing.T) {
+	inventoryPath := writeInventoryFile(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy:
+  labelKey: hami.io/mock-group
+groups:
   gpu-a100:
     nvidia:
       - id: GPU-MOCK-0
-        index: 0
         type: NVIDIA-A100-SXM4-80GB
         devmem: 81920
         devcore: 100
@@ -176,6 +222,9 @@ groups:
 	node := corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node-legacy",
+			Labels: map[string]string{
+				"hami.io/mock-group": "gpu-h100",
+			},
 			Annotations: map[string]string{
 				RegisterAnnos: `[{"id":"GPU-0","index":0,"count":10,"devmem":40960,"devcore":50,"type":"NVIDIA-Legacy","health":true}]`,
 			},
@@ -316,12 +365,12 @@ func TestGetNodeDevicesReturnsInventoryError(t *testing.T) {
 	inventoryPath := writeInventoryFile(t, `
 apiVersion: mock.hami.io/v1alpha1
 kind: MockInventory
-groupBy: {}
+groupBy:
+  labelKey: hami.io/mock-group
 groups:
   gpu-a100:
     nvidia:
       - id: GPU-MOCK-0
-        index: 0
         type: NVIDIA-A100-SXM4-80GB
         devmem: 81920
         devcore: 100

--- a/internal/pkg/api/device/nvidia/device_test.go
+++ b/internal/pkg/api/device/nvidia/device_test.go
@@ -16,12 +16,26 @@ limitations under the License.
 package nvidia
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func writeInventoryFile(t *testing.T, body string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mock-inventory.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write inventory: %v", err)
+	}
+
+	return path
+}
 
 func TestGetResource(t *testing.T) {
 
@@ -39,7 +53,7 @@ func TestGetResource(t *testing.T) {
 		DisableCoreLimit:             false,
 	}
 
-	dev := InitNvidiaDevice(config)
+	dev := InitNvidiaDevice(config, "")
 
 	// 根据提供的 annotation 创建测试节点
 	node := corev1.Node{
@@ -86,6 +100,103 @@ func TestGetResource(t *testing.T) {
 		}
 
 	})
+}
+
+func TestGetResourceUsesInventoryWithoutHealthGate(t *testing.T) {
+	inventoryPath := writeInventoryFile(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy:
+  labelKey: hami.io/mock-group
+groups:
+  gpu-a100:
+    nvidia:
+      - id: GPU-MOCK-0
+        index: 0
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: 81920
+        devcore: 100
+        count: 10
+        health: true
+`)
+
+	config := NvidiaConfig{
+		ResourceCountName:            "nvidia.com/gpu",
+		ResourceMemoryName:           "nvidia.com/gpu-memory",
+		ResourceCoreName:             "nvidia.com/gpu-core",
+		ResourceMemoryPercentageName: "nvidia.com/gpu-memory-percentage",
+	}
+	dev := InitNvidiaDevice(config, inventoryPath)
+
+	node := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-a100-0",
+			Labels: map[string]string{"hami.io/mock-group": "gpu-a100"},
+		},
+	}
+
+	got := dev.GetResource(&node)
+	if got["gpu-memory"] != 81920 {
+		t.Fatalf("expected file-backed memory 81920, got %d", got["gpu-memory"])
+	}
+	if got["gpu-core"] != 100 {
+		t.Fatalf("expected file-backed core 100, got %d", got["gpu-core"])
+	}
+	if got["gpu-memory-percentage"] != 100 {
+		t.Fatalf("expected file-backed memory percentage 100, got %d", got["gpu-memory-percentage"])
+	}
+}
+
+func TestGetResourceFallsBackToAnnotationWhenInventoryInactive(t *testing.T) {
+	inventoryPath := writeInventoryFile(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy:
+  labelKey: hami.io/mock-group
+groups:
+  gpu-a100:
+    nvidia:
+      - id: GPU-MOCK-0
+        index: 0
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: 81920
+        devcore: 100
+        count: 10
+        health: true
+`)
+
+	config := NvidiaConfig{
+		ResourceCountName:            "nvidia.com/gpu",
+		ResourceMemoryName:           "nvidia.com/gpu-memory",
+		ResourceCoreName:             "nvidia.com/gpu-core",
+		ResourceMemoryPercentageName: "nvidia.com/gpu-memory-percentage",
+	}
+	dev := InitNvidiaDevice(config, inventoryPath)
+
+	node := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-legacy",
+			Annotations: map[string]string{
+				RegisterAnnos: `[{"id":"GPU-0","index":0,"count":10,"devmem":40960,"devcore":50,"type":"NVIDIA-Legacy","health":true}]`,
+			},
+		},
+		Status: corev1.NodeStatus{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceName(config.ResourceCountName): resource.MustParse("1"),
+			},
+		},
+	}
+
+	got := dev.GetResource(&node)
+	if got["gpu-memory"] != 40960 {
+		t.Fatalf("expected annotation fallback memory 40960, got %d", got["gpu-memory"])
+	}
+	if got["gpu-core"] != 50 {
+		t.Fatalf("expected annotation fallback core 50, got %d", got["gpu-core"])
+	}
+	if got["gpu-memory-percentage"] != 100 {
+		t.Fatalf("expected annotation fallback memory percentage 100, got %d", got["gpu-memory-percentage"])
+	}
 }
 
 func TestGetNodeDevices(t *testing.T) {
@@ -198,5 +309,39 @@ func TestGetNodeDevices(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestGetNodeDevicesReturnsInventoryError(t *testing.T) {
+	inventoryPath := writeInventoryFile(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy: {}
+groups:
+  gpu-a100:
+    nvidia:
+      - id: GPU-MOCK-0
+        index: 0
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: 81920
+        devcore: 100
+        count: 10
+        health: true
+`)
+
+	dev := InitNvidiaDevice(NvidiaConfig{}, inventoryPath)
+	node := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-a100-0",
+			Labels: map[string]string{"hami.io/mock-group": "gpu-a100"},
+			Annotations: map[string]string{
+				RegisterAnnos: `[{"id":"GPU-0","index":0,"count":10,"devmem":40960,"devcore":50,"type":"NVIDIA-Legacy","health":true}]`,
+			},
+		},
+	}
+
+	_, err := dev.GetNodeDevices(&node)
+	if err == nil {
+		t.Fatalf("expected invalid inventory to return an error")
 	}
 }

--- a/internal/pkg/api/device/nvidia/device_test.go
+++ b/internal/pkg/api/device/nvidia/device_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	apidevice "github.com/HAMi/mock-device-plugin/internal/pkg/api/device"
 	corev1 "k8s.io/api/core/v1"
@@ -309,6 +310,14 @@ groups:
 	updateNodeRegisterAnnotation = func(ctx context.Context, gotNode *corev1.Node, annotation string) error {
 		if gotNode.Name != node.Name {
 			t.Fatalf("expected node %s, got %s", node.Name, gotNode.Name)
+		}
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatalf("expected annotation sync context to have a deadline")
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 || remaining > inventoryAnnotationSyncTimeout {
+			t.Fatalf("expected bounded annotation sync timeout, got remaining=%s", remaining)
 		}
 		synced = annotation
 		return nil

--- a/internal/pkg/api/device/nvidia/device_test.go
+++ b/internal/pkg/api/device/nvidia/device_test.go
@@ -16,10 +16,14 @@ limitations under the License.
 package nvidia
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	apidevice "github.com/HAMi/mock-device-plugin/internal/pkg/api/device"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -132,6 +136,18 @@ groups:
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node-a100-0",
 			Labels: map[string]string{"hami.io/mock-group": "gpu-a100"},
+			Annotations: map[string]string{
+				RegisterAnnos: apidevice.MarshalNodeDevices([]*apidevice.DeviceInfo{
+					{
+						ID:      "GPU-MOCK-0",
+						Count:   10,
+						Devmem:  81920,
+						Devcore: 100,
+						Type:    "NVIDIA-A100-SXM4-80GB",
+						Health:  true,
+					},
+				}),
+			},
 		},
 	}
 
@@ -245,6 +261,214 @@ groups:
 	}
 	if got["gpu-memory-percentage"] != 100 {
 		t.Fatalf("expected annotation fallback memory percentage 100, got %d", got["gpu-memory-percentage"])
+	}
+}
+
+func TestGetResourceSyncsInventoryAnnotationWhenDifferent(t *testing.T) {
+	inventoryPath := writeInventoryFile(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy:
+  labelKey: hami.io/mock-group
+groups:
+  gpu-a100:
+    nvidia:
+      - id: GPU-MOCK-0
+        index: 0
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: 81920
+        devcore: 100
+        count: 10
+        health: true
+`)
+
+	config := NvidiaConfig{
+		ResourceCountName:            "nvidia.com/gpu",
+		ResourceMemoryName:           "nvidia.com/gpu-memory",
+		ResourceCoreName:             "nvidia.com/gpu-core",
+		ResourceMemoryPercentageName: "nvidia.com/gpu-memory-percentage",
+	}
+	dev := InitNvidiaDevice(config, inventoryPath)
+
+	node := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-a100-0",
+			Labels: map[string]string{"hami.io/mock-group": "gpu-a100"},
+			Annotations: map[string]string{
+				RegisterAnnos: `[{"id":"GPU-OLD-0","count":10,"devmem":40960,"devcore":50,"type":"NVIDIA-Old","health":true}]`,
+			},
+		},
+	}
+
+	originalUpdater := updateNodeRegisterAnnotation
+	t.Cleanup(func() {
+		updateNodeRegisterAnnotation = originalUpdater
+	})
+
+	var synced string
+	updateNodeRegisterAnnotation = func(ctx context.Context, gotNode *corev1.Node, annotation string) error {
+		if gotNode.Name != node.Name {
+			t.Fatalf("expected node %s, got %s", node.Name, gotNode.Name)
+		}
+		synced = annotation
+		return nil
+	}
+
+	got := dev.GetResource(&node)
+	if got["gpu-memory"] != 81920 {
+		t.Fatalf("expected inventory memory 81920, got %d", got["gpu-memory"])
+	}
+	if got["gpu-core"] != 100 {
+		t.Fatalf("expected inventory core 100, got %d", got["gpu-core"])
+	}
+	if got["gpu-memory-percentage"] != 100 {
+		t.Fatalf("expected inventory memory percentage 100, got %d", got["gpu-memory-percentage"])
+	}
+	if !strings.HasPrefix(synced, "[") {
+		t.Fatalf("expected synced annotation to be JSON, got %q", synced)
+	}
+	if strings.Contains(synced, "devicevendor") {
+		t.Fatalf("expected synced annotation to omit devicevendor, got %q", synced)
+	}
+	if strings.Contains(synced, "devicepairscore") {
+		t.Fatalf("expected synced annotation to omit devicepairscore, got %q", synced)
+	}
+	if node.Annotations[RegisterAnnos] != synced {
+		t.Fatalf("expected in-memory node annotation to be updated to %q, got %q", synced, node.Annotations[RegisterAnnos])
+	}
+
+	devices, err := apidevice.UnMarshalNodeDevices(synced)
+	if err != nil {
+		t.Fatalf("expected synced annotation to decode, got %v", err)
+	}
+	if len(devices) != 1 {
+		t.Fatalf("expected 1 synced device, got %d", len(devices))
+	}
+	if devices[0].ID != "GPU-MOCK-0" || devices[0].Devmem != 81920 || devices[0].Devcore != 100 {
+		t.Fatalf("expected inventory-backed device in synced annotation, got %+v", devices[0])
+	}
+}
+
+func TestGetResourceSkipsAnnotationSyncWhenAlreadyCurrent(t *testing.T) {
+	inventoryPath := writeInventoryFile(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy:
+  labelKey: hami.io/mock-group
+groups:
+  gpu-a100:
+    nvidia:
+      - id: GPU-MOCK-0
+        index: 0
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: 81920
+        devcore: 100
+        count: 10
+        health: true
+`)
+
+	config := NvidiaConfig{
+		ResourceCountName:            "nvidia.com/gpu",
+		ResourceMemoryName:           "nvidia.com/gpu-memory",
+		ResourceCoreName:             "nvidia.com/gpu-core",
+		ResourceMemoryPercentageName: "nvidia.com/gpu-memory-percentage",
+	}
+	dev := InitNvidiaDevice(config, inventoryPath)
+
+	currentAnnotation := apidevice.MarshalNodeDevices([]*apidevice.DeviceInfo{
+		{
+			ID:      "GPU-MOCK-0",
+			Count:   10,
+			Devmem:  81920,
+			Devcore: 100,
+			Type:    "NVIDIA-A100-SXM4-80GB",
+			Health:  true,
+		},
+	})
+	node := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-a100-0",
+			Labels: map[string]string{"hami.io/mock-group": "gpu-a100"},
+			Annotations: map[string]string{
+				RegisterAnnos: currentAnnotation,
+			},
+		},
+	}
+
+	originalUpdater := updateNodeRegisterAnnotation
+	t.Cleanup(func() {
+		updateNodeRegisterAnnotation = originalUpdater
+	})
+
+	called := false
+	updateNodeRegisterAnnotation = func(ctx context.Context, gotNode *corev1.Node, annotation string) error {
+		called = true
+		return nil
+	}
+
+	got := dev.GetResource(&node)
+	if got["gpu-memory"] != 81920 {
+		t.Fatalf("expected inventory memory 81920, got %d", got["gpu-memory"])
+	}
+	if called {
+		t.Fatalf("expected annotation updater to be skipped when annotation already matches inventory")
+	}
+}
+
+func TestGetResourceReturnsZeroWhenInventoryAnnotationSyncFails(t *testing.T) {
+	inventoryPath := writeInventoryFile(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy:
+  labelKey: hami.io/mock-group
+groups:
+  gpu-a100:
+    nvidia:
+      - id: GPU-MOCK-0
+        index: 0
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: 81920
+        devcore: 100
+        count: 10
+        health: true
+`)
+
+	config := NvidiaConfig{
+		ResourceCountName:            "nvidia.com/gpu",
+		ResourceMemoryName:           "nvidia.com/gpu-memory",
+		ResourceCoreName:             "nvidia.com/gpu-core",
+		ResourceMemoryPercentageName: "nvidia.com/gpu-memory-percentage",
+	}
+	dev := InitNvidiaDevice(config, inventoryPath)
+
+	node := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-a100-0",
+			Labels: map[string]string{"hami.io/mock-group": "gpu-a100"},
+		},
+	}
+
+	originalUpdater := updateNodeRegisterAnnotation
+	t.Cleanup(func() {
+		updateNodeRegisterAnnotation = originalUpdater
+	})
+
+	updateNodeRegisterAnnotation = func(ctx context.Context, gotNode *corev1.Node, annotation string) error {
+		return errors.New("update failed")
+	}
+
+	got := dev.GetResource(&node)
+	if got["gpu-memory"] != 0 {
+		t.Fatalf("expected sync failure to suppress inventory memory, got %d", got["gpu-memory"])
+	}
+	if got["gpu-core"] != 0 {
+		t.Fatalf("expected sync failure to suppress inventory core, got %d", got["gpu-core"])
+	}
+	if got["gpu-memory-percentage"] != 0 {
+		t.Fatalf("expected sync failure to suppress inventory memory percentage, got %d", got["gpu-memory-percentage"])
+	}
+	if _, ok := node.Annotations[RegisterAnnos]; ok {
+		t.Fatalf("expected failed sync to leave node annotation unset, got %q", node.Annotations[RegisterAnnos])
 	}
 }
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -102,7 +102,7 @@ func InitDevicesWithConfig(config *Config) error {
 	if hygonDevice != nil {
 		device.DevicesMap[hygonDevice.CommonWord()] = hygonDevice
 	}
-	nvidiaDevice := nvidia.InitNvidiaDevice(config.NvidiaConfig)
+	nvidiaDevice := nvidia.InitNvidiaDevice(config.NvidiaConfig, mockInventoryFile)
 	if nvidiaDevice != nil {
 		device.DevicesMap[nvidiaDevice.CommonWord()] = nvidiaDevice
 	}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -52,7 +52,8 @@ type Config struct {
 }
 
 var (
-	configFile string
+	configFile        string
+	mockInventoryFile string
 )
 
 func LoadConfig(path string) (*Config, error) {
@@ -125,6 +126,11 @@ func InitDevices() {
 	}
 }
 
+func RegisterFlags(fs *flag.FlagSet) {
+	fs.StringVar(&configFile, "device-config-file", "", "Path to the device config file")
+	fs.StringVar(&mockInventoryFile, "mock-inventory-file", "", "Path to the mock inventory file")
+}
+
 func GlobalFlagSet() {
-	flag.StringVar(&configFile, "device-config-file", "", "Path to the device config file")
+	RegisterFlags(flag.CommandLine)
 }

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"flag"
+	"testing"
+)
+
+func TestRegisterFlagsParsesMockInventoryFile(t *testing.T) {
+	configFile = ""
+	mockInventoryFile = ""
+
+	fs := flag.NewFlagSet("mock-config", flag.ContinueOnError)
+	RegisterFlags(fs)
+
+	if err := fs.Parse([]string{
+		"--device-config-file=/tmp/device-config.yaml",
+		"--mock-inventory-file=/tmp/mock-inventory.yaml",
+	}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	if configFile != "/tmp/device-config.yaml" {
+		t.Fatalf("expected configFile to be parsed, got %q", configFile)
+	}
+	if mockInventoryFile != "/tmp/mock-inventory.yaml" {
+		t.Fatalf("expected mockInventoryFile to be parsed, got %q", mockInventoryFile)
+	}
+}

--- a/internal/pkg/mockinventory/mockinventory.go
+++ b/internal/pkg/mockinventory/mockinventory.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"strings"
 
 	"github.com/HAMi/mock-device-plugin/internal/pkg/api/device"
 	"gopkg.in/yaml.v2"
@@ -38,23 +39,7 @@ type GroupBy struct {
 }
 
 type Group struct {
-	Nvidia []*inventoryDevice `yaml:"nvidia"`
-}
-
-type inventoryDevice struct {
-	ID              *string                 `yaml:"id"`
-	Index           *uint                   `yaml:"index"`
-	Count           *int32                  `yaml:"count"`
-	Devmem          *int32                  `yaml:"devmem"`
-	Devcore         *int32                  `yaml:"devcore"`
-	Type            *string                 `yaml:"type"`
-	Numa            *int                    `yaml:"numa"`
-	Mode            *string                 `yaml:"mode"`
-	MIGTemplate     []device.Geometry       `yaml:"migtemplate"`
-	Health          *bool                   `yaml:"health"`
-	DeviceVendor    *string                 `yaml:"devicevendor"`
-	CustomInfo      map[string]any          `yaml:"custominfo"`
-	DevicePairScore *device.DevicePairScore `yaml:"devicepairscore"`
+	Nvidia []*device.DeviceInfo `yaml:"nvidia"`
 }
 
 func Load(path string) (*Inventory, error) {
@@ -104,12 +89,12 @@ func (inv *Inventory) ResolveNvidiaDevices(node *corev1.Node) ([]*device.DeviceI
 		return nil, false, nil
 	}
 
-	devs, err := group.nvidiaDevices(groupName)
+	devs, err := group.nvidiaDevices(groupName, groupData)
 	if err != nil {
 		return nil, true, err
 	}
 
-	return cloneDevices(devs), true, nil
+	return devs, true, nil
 }
 
 func decodeGroup(groupName string, data any) (*Group, error) {
@@ -126,15 +111,31 @@ func decodeGroup(groupName string, data any) (*Group, error) {
 	return &group, nil
 }
 
-func (g *Group) nvidiaDevices(groupName string) ([]*device.DeviceInfo, error) {
+func (g *Group) nvidiaDevices(groupName string, data any) ([]*device.DeviceInfo, error) {
+	rawDevices, err := decodeRawNvidiaDevices(groupName, data)
+	if err != nil {
+		return nil, err
+	}
+	if len(rawDevices) != len(g.Nvidia) {
+		return nil, fmt.Errorf("groups.%s.nvidia decode mismatch", groupName)
+	}
+
 	seenIDs := make(map[string]struct{}, len(g.Nvidia))
 	seenIndexes := make(map[uint]struct{}, len(g.Nvidia))
 	devs := make([]*device.DeviceInfo, 0, len(g.Nvidia))
 
-	for idx, gpu := range g.Nvidia {
-		devInfo, err := gpu.toDeviceInfo(groupName, idx)
-		if err != nil {
+	for idx, devInfo := range g.Nvidia {
+		if devInfo == nil {
+			return nil, fmt.Errorf("groups.%s.nvidia[%d] is nil", groupName, idx)
+		}
+		if err := validateRequiredFields(groupName, idx, rawDevices[idx], "id", "index", "count", "devmem", "devcore", "type", "health"); err != nil {
 			return nil, err
+		}
+		if strings.TrimSpace(devInfo.ID) == "" {
+			return nil, fmt.Errorf("groups.%s.nvidia[%d].id is required", groupName, idx)
+		}
+		if strings.TrimSpace(devInfo.Type) == "" {
+			return nil, fmt.Errorf("groups.%s.nvidia[%d].type is required", groupName, idx)
 		}
 		if _, ok := seenIDs[devInfo.ID]; ok {
 			return nil, fmt.Errorf("groups.%s.nvidia[%d].id %q is duplicated", groupName, idx, devInfo.ID)
@@ -151,87 +152,36 @@ func (g *Group) nvidiaDevices(groupName string) ([]*device.DeviceInfo, error) {
 		devs = append(devs, devInfo)
 	}
 
-	return devs, nil
+	return cloneDevices(devs), nil
 }
 
-func (d *inventoryDevice) toDeviceInfo(groupName string, index int) (*device.DeviceInfo, error) {
-	if d == nil {
-		return nil, fmt.Errorf("groups.%s.nvidia[%d] is nil", groupName, index)
+func decodeRawNvidiaDevices(groupName string, data any) ([]map[string]any, error) {
+	groupYAML, err := yaml.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("marshal raw groups.%s: %w", groupName, err)
 	}
 
-	id, err := requiredString(groupName, index, "id", d.ID)
-	if err != nil {
-		return nil, err
+	var raw struct {
+		Nvidia []map[string]any `yaml:"nvidia"`
 	}
-	deviceType, err := requiredString(groupName, index, "type", d.Type)
-	if err != nil {
-		return nil, err
-	}
-	deviceIndex, err := requiredValue(groupName, index, "index", d.Index)
-	if err != nil {
-		return nil, err
-	}
-	count, err := requiredValue(groupName, index, "count", d.Count)
-	if err != nil {
-		return nil, err
-	}
-	devmem, err := requiredValue(groupName, index, "devmem", d.Devmem)
-	if err != nil {
-		return nil, err
-	}
-	devcore, err := requiredValue(groupName, index, "devcore", d.Devcore)
-	if err != nil {
-		return nil, err
-	}
-	health, err := requiredValue(groupName, index, "health", d.Health)
-	if err != nil {
-		return nil, err
+	if err := yaml.Unmarshal(groupYAML, &raw); err != nil {
+		return nil, fmt.Errorf("decode raw groups.%s: %w", groupName, err)
 	}
 
-	devInfo := &device.DeviceInfo{
-		ID:          id,
-		Index:       deviceIndex,
-		Count:       count,
-		Devmem:      devmem,
-		Devcore:     devcore,
-		Type:        deviceType,
-		Health:      health,
-		MIGTemplate: cloneMigTemplate(d.MIGTemplate),
-		CustomInfo:  maps.Clone(d.CustomInfo),
-	}
-	if d.Numa != nil {
-		devInfo.Numa = *d.Numa
-	}
-	if d.Mode != nil {
-		devInfo.Mode = *d.Mode
-	}
-	if d.DeviceVendor != nil {
-		devInfo.DeviceVendor = *d.DeviceVendor
-	}
-	if d.DevicePairScore != nil {
-		devInfo.DevicePairScore = cloneDevicePairScore(*d.DevicePairScore)
-	}
-
-	return devInfo, nil
+	return raw.Nvidia, nil
 }
 
-func requiredString(groupName string, index int, field string, value *string) (string, error) {
-	result, err := requiredValue(groupName, index, field, value)
-	if err != nil {
-		return "", err
+func validateRequiredFields(groupName string, index int, raw map[string]any, fields ...string) error {
+	if raw == nil {
+		return fmt.Errorf("groups.%s.nvidia[%d] is nil", groupName, index)
 	}
-	if result == "" {
-		return "", fmt.Errorf("groups.%s.nvidia[%d].%s is required", groupName, index, field)
+	for _, field := range fields {
+		value, ok := raw[field]
+		if !ok || value == nil {
+			return fmt.Errorf("groups.%s.nvidia[%d].%s is required", groupName, index, field)
+		}
 	}
-	return result, nil
-}
-
-func requiredValue[T any](groupName string, index int, field string, value *T) (T, error) {
-	var zero T
-	if value == nil {
-		return zero, fmt.Errorf("groups.%s.nvidia[%d].%s is required", groupName, index, field)
-	}
-	return *value, nil
+	return nil
 }
 
 func cloneDevices(in []*device.DeviceInfo) []*device.DeviceInfo {

--- a/internal/pkg/mockinventory/mockinventory.go
+++ b/internal/pkg/mockinventory/mockinventory.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2025 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockinventory
+
+import (
+	"fmt"
+	"maps"
+	"os"
+
+	"github.com/HAMi/mock-device-plugin/internal/pkg/api/device"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type Inventory struct {
+	APIVersion string           `yaml:"apiVersion"`
+	Kind       string           `yaml:"kind"`
+	GroupBy    GroupBy          `yaml:"groupBy"`
+	Groups     map[string]Group `yaml:"groups"`
+}
+
+type GroupBy struct {
+	LabelKey string `yaml:"labelKey"`
+}
+
+type Group struct {
+	Nvidia []*device.DeviceInfo `yaml:"nvidia"`
+}
+
+func Load(path string) (*Inventory, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var inv Inventory
+	if err := yaml.Unmarshal(data, &inv); err != nil {
+		return nil, err
+	}
+	if err := inv.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &inv, nil
+}
+
+func (inv *Inventory) Validate() error {
+	if inv.GroupBy.LabelKey == "" {
+		return fmt.Errorf("groupBy.labelKey is required")
+	}
+
+	return nil
+}
+
+func (inv *Inventory) ResolveNvidiaDevices(node *corev1.Node) ([]*device.DeviceInfo, bool, error) {
+	if inv == nil || node == nil {
+		return nil, false, nil
+	}
+
+	groupName, ok := node.Labels[inv.GroupBy.LabelKey]
+	if !ok || groupName == "" {
+		return nil, false, nil
+	}
+
+	group, ok := inv.Groups[groupName]
+	if !ok || len(group.Nvidia) == 0 {
+		return nil, false, nil
+	}
+
+	return cloneDevices(group.Nvidia), true, nil
+}
+
+func cloneDevices(in []*device.DeviceInfo) []*device.DeviceInfo {
+	out := make([]*device.DeviceInfo, 0, len(in))
+	for _, item := range in {
+		if item == nil {
+			continue
+		}
+
+		cloned := *item
+		cloned.CustomInfo = maps.Clone(item.CustomInfo)
+		cloned.DevicePairScore = cloneDevicePairScore(item.DevicePairScore)
+		cloned.MIGTemplate = cloneMigTemplate(item.MIGTemplate)
+		out = append(out, &cloned)
+	}
+
+	return out
+}
+
+func cloneDevicePairScore(in device.DevicePairScore) device.DevicePairScore {
+	in.Scores = maps.Clone(in.Scores)
+	return in
+}
+
+func cloneMigTemplate(in []device.Geometry) []device.Geometry {
+	if in == nil {
+		return nil
+	}
+
+	out := make([]device.Geometry, 0, len(in))
+	for _, geometry := range in {
+		if geometry == nil {
+			out = append(out, nil)
+			continue
+		}
+
+		geometryCopy := append(device.Geometry(nil), geometry...)
+		out = append(out, geometryCopy)
+	}
+
+	return out
+}

--- a/internal/pkg/mockinventory/mockinventory.go
+++ b/internal/pkg/mockinventory/mockinventory.go
@@ -63,6 +63,29 @@ func (inv *Inventory) Validate() error {
 		return fmt.Errorf("groupBy.labelKey is required")
 	}
 
+	for groupName, group := range inv.Groups {
+		seenIDs := make(map[string]struct{}, len(group.Nvidia))
+		seenIndexes := make(map[uint]struct{}, len(group.Nvidia))
+
+		for _, gpu := range group.Nvidia {
+			if gpu == nil {
+				return fmt.Errorf("groups.%s.nvidia contains nil entry", groupName)
+			}
+			if _, ok := seenIDs[gpu.ID]; ok {
+				return fmt.Errorf("groups.%s.nvidia contains duplicate id %q", groupName, gpu.ID)
+			}
+			if _, ok := seenIndexes[gpu.Index]; ok {
+				return fmt.Errorf("groups.%s.nvidia contains duplicate index %d", groupName, gpu.Index)
+			}
+			if gpu.Count < 0 || gpu.Devmem < 0 || gpu.Devcore < 0 || gpu.Numa < 0 {
+				return fmt.Errorf("groups.%s.nvidia contains negative numeric value", groupName)
+			}
+
+			seenIDs[gpu.ID] = struct{}{}
+			seenIndexes[gpu.Index] = struct{}{}
+		}
+	}
+
 	return nil
 }
 

--- a/internal/pkg/mockinventory/mockinventory.go
+++ b/internal/pkg/mockinventory/mockinventory.go
@@ -27,10 +27,10 @@ import (
 )
 
 type Inventory struct {
-	APIVersion string           `yaml:"apiVersion"`
-	Kind       string           `yaml:"kind"`
-	GroupBy    GroupBy          `yaml:"groupBy"`
-	Groups     map[string]Group `yaml:"groups"`
+	APIVersion string         `yaml:"apiVersion"`
+	Kind       string         `yaml:"kind"`
+	GroupBy    GroupBy        `yaml:"groupBy"`
+	Groups     map[string]any `yaml:"groups"`
 }
 
 type GroupBy struct {
@@ -38,7 +38,23 @@ type GroupBy struct {
 }
 
 type Group struct {
-	Nvidia []*device.DeviceInfo `yaml:"nvidia"`
+	Nvidia []*inventoryDevice `yaml:"nvidia"`
+}
+
+type inventoryDevice struct {
+	ID              *string                 `yaml:"id"`
+	Index           *uint                   `yaml:"index"`
+	Count           *int32                  `yaml:"count"`
+	Devmem          *int32                  `yaml:"devmem"`
+	Devcore         *int32                  `yaml:"devcore"`
+	Type            *string                 `yaml:"type"`
+	Numa            *int                    `yaml:"numa"`
+	Mode            *string                 `yaml:"mode"`
+	MIGTemplate     []device.Geometry       `yaml:"migtemplate"`
+	Health          *bool                   `yaml:"health"`
+	DeviceVendor    *string                 `yaml:"devicevendor"`
+	CustomInfo      map[string]any          `yaml:"custominfo"`
+	DevicePairScore *device.DevicePairScore `yaml:"devicepairscore"`
 }
 
 func Load(path string) (*Inventory, error) {
@@ -48,7 +64,7 @@ func Load(path string) (*Inventory, error) {
 	}
 
 	var inv Inventory
-	if err := yaml.Unmarshal(data, &inv); err != nil {
+	if err := yaml.UnmarshalStrict(data, &inv); err != nil {
 		return nil, err
 	}
 	if err := inv.Validate(); err != nil {
@@ -62,36 +78,6 @@ func (inv *Inventory) Validate() error {
 	if inv.GroupBy.LabelKey == "" {
 		return fmt.Errorf("groupBy.labelKey is required")
 	}
-
-	for groupName, group := range inv.Groups {
-		seenIDs := make(map[string]struct{}, len(group.Nvidia))
-		seenIndexes := make(map[uint]struct{}, len(group.Nvidia))
-
-		for _, gpu := range group.Nvidia {
-			if gpu == nil {
-				return fmt.Errorf("groups.%s.nvidia contains nil entry", groupName)
-			}
-			if gpu.ID == "" {
-				return fmt.Errorf("groups.%s.nvidia contains empty id", groupName)
-			}
-			if gpu.Type == "" {
-				return fmt.Errorf("groups.%s.nvidia contains empty type", groupName)
-			}
-			if _, ok := seenIDs[gpu.ID]; ok {
-				return fmt.Errorf("groups.%s.nvidia contains duplicate id %q", groupName, gpu.ID)
-			}
-			if _, ok := seenIndexes[gpu.Index]; ok {
-				return fmt.Errorf("groups.%s.nvidia contains duplicate index %d", groupName, gpu.Index)
-			}
-			if gpu.Count < 0 || gpu.Devmem < 0 || gpu.Devcore < 0 || gpu.Numa < 0 {
-				return fmt.Errorf("groups.%s.nvidia contains negative numeric value", groupName)
-			}
-
-			seenIDs[gpu.ID] = struct{}{}
-			seenIndexes[gpu.Index] = struct{}{}
-		}
-	}
-
 	return nil
 }
 
@@ -105,12 +91,147 @@ func (inv *Inventory) ResolveNvidiaDevices(node *corev1.Node) ([]*device.DeviceI
 		return nil, false, nil
 	}
 
-	group, ok := inv.Groups[groupName]
-	if !ok || len(group.Nvidia) == 0 {
+	groupData, ok := inv.Groups[groupName]
+	if !ok {
 		return nil, false, nil
 	}
 
-	return cloneDevices(group.Nvidia), true, nil
+	group, err := decodeGroup(groupName, groupData)
+	if err != nil {
+		return nil, true, err
+	}
+	if len(group.Nvidia) == 0 {
+		return nil, false, nil
+	}
+
+	devs, err := group.nvidiaDevices(groupName)
+	if err != nil {
+		return nil, true, err
+	}
+
+	return cloneDevices(devs), true, nil
+}
+
+func decodeGroup(groupName string, data any) (*Group, error) {
+	groupYAML, err := yaml.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("marshal groups.%s: %w", groupName, err)
+	}
+
+	var group Group
+	if err := yaml.UnmarshalStrict(groupYAML, &group); err != nil {
+		return nil, fmt.Errorf("decode groups.%s: %w", groupName, err)
+	}
+
+	return &group, nil
+}
+
+func (g *Group) nvidiaDevices(groupName string) ([]*device.DeviceInfo, error) {
+	seenIDs := make(map[string]struct{}, len(g.Nvidia))
+	seenIndexes := make(map[uint]struct{}, len(g.Nvidia))
+	devs := make([]*device.DeviceInfo, 0, len(g.Nvidia))
+
+	for idx, gpu := range g.Nvidia {
+		devInfo, err := gpu.toDeviceInfo(groupName, idx)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seenIDs[devInfo.ID]; ok {
+			return nil, fmt.Errorf("groups.%s.nvidia[%d].id %q is duplicated", groupName, idx, devInfo.ID)
+		}
+		if _, ok := seenIndexes[devInfo.Index]; ok {
+			return nil, fmt.Errorf("groups.%s.nvidia[%d].index %d is duplicated", groupName, idx, devInfo.Index)
+		}
+		if devInfo.Count < 0 || devInfo.Devmem < 0 || devInfo.Devcore < 0 || devInfo.Numa < 0 {
+			return nil, fmt.Errorf("groups.%s.nvidia[%d] contains negative numeric value", groupName, idx)
+		}
+
+		seenIDs[devInfo.ID] = struct{}{}
+		seenIndexes[devInfo.Index] = struct{}{}
+		devs = append(devs, devInfo)
+	}
+
+	return devs, nil
+}
+
+func (d *inventoryDevice) toDeviceInfo(groupName string, index int) (*device.DeviceInfo, error) {
+	if d == nil {
+		return nil, fmt.Errorf("groups.%s.nvidia[%d] is nil", groupName, index)
+	}
+
+	id, err := requiredString(groupName, index, "id", d.ID)
+	if err != nil {
+		return nil, err
+	}
+	deviceType, err := requiredString(groupName, index, "type", d.Type)
+	if err != nil {
+		return nil, err
+	}
+	deviceIndex, err := requiredValue(groupName, index, "index", d.Index)
+	if err != nil {
+		return nil, err
+	}
+	count, err := requiredValue(groupName, index, "count", d.Count)
+	if err != nil {
+		return nil, err
+	}
+	devmem, err := requiredValue(groupName, index, "devmem", d.Devmem)
+	if err != nil {
+		return nil, err
+	}
+	devcore, err := requiredValue(groupName, index, "devcore", d.Devcore)
+	if err != nil {
+		return nil, err
+	}
+	health, err := requiredValue(groupName, index, "health", d.Health)
+	if err != nil {
+		return nil, err
+	}
+
+	devInfo := &device.DeviceInfo{
+		ID:          id,
+		Index:       deviceIndex,
+		Count:       count,
+		Devmem:      devmem,
+		Devcore:     devcore,
+		Type:        deviceType,
+		Health:      health,
+		MIGTemplate: cloneMigTemplate(d.MIGTemplate),
+		CustomInfo:  maps.Clone(d.CustomInfo),
+	}
+	if d.Numa != nil {
+		devInfo.Numa = *d.Numa
+	}
+	if d.Mode != nil {
+		devInfo.Mode = *d.Mode
+	}
+	if d.DeviceVendor != nil {
+		devInfo.DeviceVendor = *d.DeviceVendor
+	}
+	if d.DevicePairScore != nil {
+		devInfo.DevicePairScore = cloneDevicePairScore(*d.DevicePairScore)
+	}
+
+	return devInfo, nil
+}
+
+func requiredString(groupName string, index int, field string, value *string) (string, error) {
+	result, err := requiredValue(groupName, index, field, value)
+	if err != nil {
+		return "", err
+	}
+	if result == "" {
+		return "", fmt.Errorf("groups.%s.nvidia[%d].%s is required", groupName, index, field)
+	}
+	return result, nil
+}
+
+func requiredValue[T any](groupName string, index int, field string, value *T) (T, error) {
+	var zero T
+	if value == nil {
+		return zero, fmt.Errorf("groups.%s.nvidia[%d].%s is required", groupName, index, field)
+	}
+	return *value, nil
 }
 
 func cloneDevices(in []*device.DeviceInfo) []*device.DeviceInfo {

--- a/internal/pkg/mockinventory/mockinventory.go
+++ b/internal/pkg/mockinventory/mockinventory.go
@@ -71,6 +71,12 @@ func (inv *Inventory) Validate() error {
 			if gpu == nil {
 				return fmt.Errorf("groups.%s.nvidia contains nil entry", groupName)
 			}
+			if gpu.ID == "" {
+				return fmt.Errorf("groups.%s.nvidia contains empty id", groupName)
+			}
+			if gpu.Type == "" {
+				return fmt.Errorf("groups.%s.nvidia contains empty type", groupName)
+			}
 			if _, ok := seenIDs[gpu.ID]; ok {
 				return fmt.Errorf("groups.%s.nvidia contains duplicate id %q", groupName, gpu.ID)
 			}

--- a/internal/pkg/mockinventory/mockinventory_test.go
+++ b/internal/pkg/mockinventory/mockinventory_test.go
@@ -3,6 +3,7 @@ package mockinventory
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/HAMi/mock-device-plugin/internal/pkg/api/device"
@@ -22,8 +23,33 @@ func writeInventoryFile(t *testing.T, body string) string {
 	return path
 }
 
+func loadInventory(t *testing.T, body string) *Inventory {
+	t.Helper()
+
+	inv, err := Load(writeInventoryFile(t, body))
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	return inv
+}
+
+func resolveNvidiaDevices(t *testing.T, body string, labels map[string]string) ([]*device.DeviceInfo, bool, error) {
+	t.Helper()
+
+	inv := loadInventory(t, body)
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-0",
+			Labels: labels,
+		},
+	}
+
+	return inv.ResolveNvidiaDevices(node)
+}
+
 func TestLoadResolveNvidiaDevicesForMatchingGroup(t *testing.T) {
-	path := writeInventoryFile(t, `
+	devs, active, err := resolveNvidiaDevices(t, `
 apiVersion: mock.hami.io/v1alpha1
 kind: MockInventory
 groupBy:
@@ -38,21 +64,7 @@ groups:
         devcore: 100
         count: 10
         health: true
-`)
-
-	inv, err := Load(path)
-	if err != nil {
-		t.Fatalf("Load() error = %v", err)
-	}
-
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "node-a100-0",
-			Labels: map[string]string{"hami.io/mock-group": "gpu-a100"},
-		},
-	}
-
-	devs, active, err := inv.ResolveNvidiaDevices(node)
+`, map[string]string{"hami.io/mock-group": "gpu-a100"})
 	if err != nil {
 		t.Fatalf("ResolveNvidiaDevices() error = %v", err)
 	}
@@ -68,7 +80,7 @@ groups:
 }
 
 func TestResolveNvidiaDevicesWithoutMatchingLabelFallsBack(t *testing.T) {
-	path := writeInventoryFile(t, `
+	devs, active, err := resolveNvidiaDevices(t, `
 apiVersion: mock.hami.io/v1alpha1
 kind: MockInventory
 groupBy:
@@ -83,21 +95,7 @@ groups:
         devcore: 100
         count: 10
         health: true
-`)
-
-	inv, err := Load(path)
-	if err != nil {
-		t.Fatalf("Load() error = %v", err)
-	}
-
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "node-no-group",
-			Labels: map[string]string{},
-		},
-	}
-
-	devs, active, err := inv.ResolveNvidiaDevices(node)
+`, nil)
 	if err != nil {
 		t.Fatalf("ResolveNvidiaDevices() error = %v", err)
 	}
@@ -109,8 +107,55 @@ groups:
 	}
 }
 
+func TestResolveNvidiaDevicesWithoutNvidiaSectionFallsBack(t *testing.T) {
+	devs, active, err := resolveNvidiaDevices(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy:
+  labelKey: hami.io/mock-group
+groups:
+  gpu-a100: {}
+`, map[string]string{"hami.io/mock-group": "gpu-a100"})
+	if err != nil {
+		t.Fatalf("ResolveNvidiaDevices() error = %v", err)
+	}
+	if active {
+		t.Fatalf("expected fallback path for group without nvidia devices")
+	}
+	if len(devs) != 0 {
+		t.Fatalf("expected 0 devices on fallback, got %d", len(devs))
+	}
+}
+
+func TestResolveNvidiaDevicesIgnoresInvalidUnmatchedGroup(t *testing.T) {
+	devs, active, err := resolveNvidiaDevices(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy:
+  labelKey: hami.io/mock-group
+groups:
+  gpu-a100:
+    nvidia:
+      - id: GPU-MOCK-0
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: 81920
+        devcore: 100
+        count: 10
+        health: true
+`, map[string]string{"hami.io/mock-group": "gpu-h100"})
+	if err != nil {
+		t.Fatalf("expected unmatched invalid group not to error, got %v", err)
+	}
+	if active {
+		t.Fatalf("expected fallback path for unmatched group")
+	}
+	if len(devs) != 0 {
+		t.Fatalf("expected 0 devices on fallback, got %d", len(devs))
+	}
+}
+
 func TestResolveNvidiaDevicesClonesReturnedEntries(t *testing.T) {
-	path := writeInventoryFile(t, `
+	inv := loadInventory(t, `
 apiVersion: mock.hami.io/v1alpha1
 kind: MockInventory
 groupBy:
@@ -126,11 +171,6 @@ groups:
         count: 10
         health: true
 `)
-
-	inv, err := Load(path)
-	if err != nil {
-		t.Fatalf("Load() error = %v", err)
-	}
 
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -156,7 +196,7 @@ groups:
 }
 
 func TestLoadRejectsMissingLabelKey(t *testing.T) {
-	path := writeInventoryFile(t, `
+	_, err := Load(writeInventoryFile(t, `
 apiVersion: mock.hami.io/v1alpha1
 kind: MockInventory
 groupBy: {}
@@ -170,16 +210,69 @@ groups:
         devcore: 100
         count: 10
         health: true
-`)
-
-	_, err := Load(path)
+`))
 	if err == nil {
 		t.Fatalf("expected missing labelKey error")
 	}
 }
 
-func TestLoadRejectsDuplicateDeviceIDs(t *testing.T) {
-	path := writeInventoryFile(t, `
+func TestResolveNvidiaDevicesRejectsMissingRequiredField(t *testing.T) {
+	_, active, err := resolveNvidiaDevices(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy:
+  labelKey: hami.io/mock-group
+groups:
+  gpu-a100:
+    nvidia:
+      - id: GPU-MOCK-0
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: 81920
+        devcore: 100
+        count: 10
+        health: true
+`, map[string]string{"hami.io/mock-group": "gpu-a100"})
+	if err == nil {
+		t.Fatalf("expected missing required field error")
+	}
+	if !active {
+		t.Fatalf("expected matched invalid group to stay on fail-fast path")
+	}
+	if !strings.Contains(err.Error(), "groups.gpu-a100.nvidia[0].index is required") {
+		t.Fatalf("expected index-required error, got %v", err)
+	}
+}
+
+func TestResolveNvidiaDevicesRejectsMisspelledRequiredField(t *testing.T) {
+	_, active, err := resolveNvidiaDevices(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy:
+  labelKey: hami.io/mock-group
+groups:
+  gpu-a100:
+    nvidia:
+      - id: GPU-MOCK-0
+        index: 0
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: 81920
+        devcor: 100
+        count: 10
+        health: true
+`, map[string]string{"hami.io/mock-group": "gpu-a100"})
+	if err == nil {
+		t.Fatalf("expected strict decode error for misspelled field")
+	}
+	if !active {
+		t.Fatalf("expected matched invalid group to stay on fail-fast path")
+	}
+	if !strings.Contains(err.Error(), "groups.gpu-a100") {
+		t.Fatalf("expected group-qualified error, got %v", err)
+	}
+}
+
+func TestResolveNvidiaDevicesRejectsDuplicateDeviceIDs(t *testing.T) {
+	_, _, err := resolveNvidiaDevices(t, `
 apiVersion: mock.hami.io/v1alpha1
 kind: MockInventory
 groupBy:
@@ -201,16 +294,14 @@ groups:
         devcore: 100
         count: 10
         health: true
-`)
-
-	_, err := Load(path)
+`, map[string]string{"hami.io/mock-group": "gpu-a100"})
 	if err == nil {
 		t.Fatalf("expected duplicate id error")
 	}
 }
 
-func TestLoadRejectsDuplicateIndexes(t *testing.T) {
-	path := writeInventoryFile(t, `
+func TestResolveNvidiaDevicesRejectsDuplicateIndexes(t *testing.T) {
+	_, _, err := resolveNvidiaDevices(t, `
 apiVersion: mock.hami.io/v1alpha1
 kind: MockInventory
 groupBy:
@@ -232,16 +323,14 @@ groups:
         devcore: 100
         count: 10
         health: true
-`)
-
-	_, err := Load(path)
+`, map[string]string{"hami.io/mock-group": "gpu-a100"})
 	if err == nil {
 		t.Fatalf("expected duplicate index error")
 	}
 }
 
-func TestLoadRejectsNegativeNumericFields(t *testing.T) {
-	path := writeInventoryFile(t, `
+func TestResolveNvidiaDevicesRejectsNegativeNumericFields(t *testing.T) {
+	_, _, err := resolveNvidiaDevices(t, `
 apiVersion: mock.hami.io/v1alpha1
 kind: MockInventory
 groupBy:
@@ -256,16 +345,14 @@ groups:
         devcore: 100
         count: 10
         health: true
-`)
-
-	_, err := Load(path)
+`, map[string]string{"hami.io/mock-group": "gpu-a100"})
 	if err == nil {
 		t.Fatalf("expected negative numeric field error")
 	}
 }
 
-func TestLoadRejectsEmptyDeviceID(t *testing.T) {
-	path := writeInventoryFile(t, `
+func TestResolveNvidiaDevicesRejectsEmptyDeviceID(t *testing.T) {
+	_, _, err := resolveNvidiaDevices(t, `
 apiVersion: mock.hami.io/v1alpha1
 kind: MockInventory
 groupBy:
@@ -280,16 +367,14 @@ groups:
         devcore: 100
         count: 10
         health: true
-`)
-
-	_, err := Load(path)
+`, map[string]string{"hami.io/mock-group": "gpu-a100"})
 	if err == nil {
 		t.Fatalf("expected empty id error")
 	}
 }
 
-func TestLoadRejectsEmptyDeviceType(t *testing.T) {
-	path := writeInventoryFile(t, `
+func TestResolveNvidiaDevicesRejectsEmptyDeviceType(t *testing.T) {
+	_, _, err := resolveNvidiaDevices(t, `
 apiVersion: mock.hami.io/v1alpha1
 kind: MockInventory
 groupBy:
@@ -304,12 +389,8 @@ groups:
         devcore: 100
         count: 10
         health: true
-`)
-
-	_, err := Load(path)
+`, map[string]string{"hami.io/mock-group": "gpu-a100"})
 	if err == nil {
 		t.Fatalf("expected empty type error")
 	}
 }
-
-var _ = device.DeviceInfo{}

--- a/internal/pkg/mockinventory/mockinventory_test.go
+++ b/internal/pkg/mockinventory/mockinventory_test.go
@@ -264,4 +264,52 @@ groups:
 	}
 }
 
+func TestLoadRejectsEmptyDeviceID(t *testing.T) {
+	path := writeInventoryFile(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy:
+  labelKey: hami.io/mock-group
+groups:
+  gpu-a100:
+    nvidia:
+      - id: ""
+        index: 0
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: 81920
+        devcore: 100
+        count: 10
+        health: true
+`)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatalf("expected empty id error")
+	}
+}
+
+func TestLoadRejectsEmptyDeviceType(t *testing.T) {
+	path := writeInventoryFile(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy:
+  labelKey: hami.io/mock-group
+groups:
+  gpu-a100:
+    nvidia:
+      - id: GPU-MOCK-0
+        index: 0
+        type: ""
+        devmem: 81920
+        devcore: 100
+        count: 10
+        health: true
+`)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatalf("expected empty type error")
+	}
+}
+
 var _ = device.DeviceInfo{}

--- a/internal/pkg/mockinventory/mockinventory_test.go
+++ b/internal/pkg/mockinventory/mockinventory_test.go
@@ -1,0 +1,158 @@
+package mockinventory
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/HAMi/mock-device-plugin/internal/pkg/api/device"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func writeInventoryFile(t *testing.T, body string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mock-inventory.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write inventory: %v", err)
+	}
+
+	return path
+}
+
+func TestLoadResolveNvidiaDevicesForMatchingGroup(t *testing.T) {
+	path := writeInventoryFile(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy:
+  labelKey: hami.io/mock-group
+groups:
+  gpu-a100:
+    nvidia:
+      - id: GPU-MOCK-0
+        index: 0
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: 81920
+        devcore: 100
+        count: 10
+        health: true
+`)
+
+	inv, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-a100-0",
+			Labels: map[string]string{"hami.io/mock-group": "gpu-a100"},
+		},
+	}
+
+	devs, active, err := inv.ResolveNvidiaDevices(node)
+	if err != nil {
+		t.Fatalf("ResolveNvidiaDevices() error = %v", err)
+	}
+	if !active {
+		t.Fatalf("expected active inventory path")
+	}
+	if len(devs) != 1 {
+		t.Fatalf("expected 1 device, got %d", len(devs))
+	}
+	if devs[0].ID != "GPU-MOCK-0" {
+		t.Fatalf("expected GPU-MOCK-0, got %s", devs[0].ID)
+	}
+}
+
+func TestResolveNvidiaDevicesWithoutMatchingLabelFallsBack(t *testing.T) {
+	path := writeInventoryFile(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy:
+  labelKey: hami.io/mock-group
+groups:
+  gpu-a100:
+    nvidia:
+      - id: GPU-MOCK-0
+        index: 0
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: 81920
+        devcore: 100
+        count: 10
+        health: true
+`)
+
+	inv, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-no-group",
+			Labels: map[string]string{},
+		},
+	}
+
+	devs, active, err := inv.ResolveNvidiaDevices(node)
+	if err != nil {
+		t.Fatalf("ResolveNvidiaDevices() error = %v", err)
+	}
+	if active {
+		t.Fatalf("expected fallback path, got active inventory path")
+	}
+	if len(devs) != 0 {
+		t.Fatalf("expected 0 devices on fallback, got %d", len(devs))
+	}
+}
+
+func TestResolveNvidiaDevicesClonesReturnedEntries(t *testing.T) {
+	path := writeInventoryFile(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy:
+  labelKey: hami.io/mock-group
+groups:
+  gpu-a100:
+    nvidia:
+      - id: GPU-MOCK-0
+        index: 0
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: 81920
+        devcore: 100
+        count: 10
+        health: true
+`)
+
+	inv, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-a100-0",
+			Labels: map[string]string{"hami.io/mock-group": "gpu-a100"},
+		},
+	}
+
+	devs, active, err := inv.ResolveNvidiaDevices(node)
+	if err != nil || !active {
+		t.Fatalf("ResolveNvidiaDevices() active=%v err=%v", active, err)
+	}
+
+	devs[0].Type = "mutated"
+
+	devs2, active, err := inv.ResolveNvidiaDevices(node)
+	if err != nil || !active {
+		t.Fatalf("ResolveNvidiaDevices() second call active=%v err=%v", active, err)
+	}
+	if devs2[0].Type != "NVIDIA-A100-SXM4-80GB" {
+		t.Fatalf("expected original type to survive clone, got %s", devs2[0].Type)
+	}
+}
+
+var _ = device.DeviceInfo{}

--- a/internal/pkg/mockinventory/mockinventory_test.go
+++ b/internal/pkg/mockinventory/mockinventory_test.go
@@ -155,4 +155,113 @@ groups:
 	}
 }
 
+func TestLoadRejectsMissingLabelKey(t *testing.T) {
+	path := writeInventoryFile(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy: {}
+groups:
+  gpu-a100:
+    nvidia:
+      - id: GPU-MOCK-0
+        index: 0
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: 81920
+        devcore: 100
+        count: 10
+        health: true
+`)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatalf("expected missing labelKey error")
+	}
+}
+
+func TestLoadRejectsDuplicateDeviceIDs(t *testing.T) {
+	path := writeInventoryFile(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy:
+  labelKey: hami.io/mock-group
+groups:
+  gpu-a100:
+    nvidia:
+      - id: GPU-MOCK-0
+        index: 0
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: 81920
+        devcore: 100
+        count: 10
+        health: true
+      - id: GPU-MOCK-0
+        index: 1
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: 81920
+        devcore: 100
+        count: 10
+        health: true
+`)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatalf("expected duplicate id error")
+	}
+}
+
+func TestLoadRejectsDuplicateIndexes(t *testing.T) {
+	path := writeInventoryFile(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy:
+  labelKey: hami.io/mock-group
+groups:
+  gpu-a100:
+    nvidia:
+      - id: GPU-MOCK-0
+        index: 0
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: 81920
+        devcore: 100
+        count: 10
+        health: true
+      - id: GPU-MOCK-1
+        index: 0
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: 81920
+        devcore: 100
+        count: 10
+        health: true
+`)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatalf("expected duplicate index error")
+	}
+}
+
+func TestLoadRejectsNegativeNumericFields(t *testing.T) {
+	path := writeInventoryFile(t, `
+apiVersion: mock.hami.io/v1alpha1
+kind: MockInventory
+groupBy:
+  labelKey: hami.io/mock-group
+groups:
+  gpu-a100:
+    nvidia:
+      - id: GPU-MOCK-0
+        index: 0
+        type: NVIDIA-A100-SXM4-80GB
+        devmem: -1
+        devcore: 100
+        count: 10
+        health: true
+`)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatalf("expected negative numeric field error")
+	}
+}
+
 var _ = device.DeviceInfo{}

--- a/k8s-mock-plugin.yaml
+++ b/k8s-mock-plugin.yaml
@@ -19,7 +19,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       containers:
-      - image: projecthami/mock-device-plugin:latest 
+      - image: projecthami/mock-device-plugin:latest
         name: hami-mock-dp-cntr
         env:
           - name: NODE_NAME
@@ -30,6 +30,7 @@ spec:
           - ./k8s-device-plugin
           - -v=5
           - --device-config-file=/device-config.yaml
+          - --mock-inventory-file=/mock-inventory/mock-inventory.yaml
         volumeMounts:
           - name: dp
             mountPath: /var/lib/kubelet/device-plugins
@@ -38,6 +39,9 @@ spec:
           - name: device-config
             mountPath: /device-config.yaml
             subPath: device-config.yaml
+          - name: mock-inventory
+            mountPath: /mock-inventory
+            readOnly: true
       volumes:
         - name: dp
           hostPath:
@@ -48,4 +52,7 @@ spec:
         - name: device-config
           configMap:
             name: hami-scheduler-device
-
+        - name: mock-inventory
+          configMap:
+            name: hami-mock-inventory
+            optional: true


### PR DESCRIPTION
**Most of this Pull Request was generated or revised with the assistance of AI tools, including Codex and Raft(Slock). I have reviewed the resulting content and take full responsibility for its accuracy, security, licensing compliance, and inclusion in this project.**

## Summary
- add a ConfigMap-backed mock inventory loader that resolves devices by node group label
- wire an optional `--mock-inventory-file` path into the NVIDIA mock-device flow and deployment manifest
- treat ConfigMap inventory as the declarative source for `hami.io/node-nvidia-register` on matched nodes, and rewrite that annotation to the normalized JSON form before advertising resources
- preserve the existing annotation contract as the scheduler-facing compatibility path, with annotation fallback when inventory is inactive
- document the recommended ConfigMap workflow in the README

## Why
This implements the user-facing request in Project-HAMi/HAMi#2023: make mock-device declaration group-based and declarative without changing HAMi's existing scheduler-facing node annotation contract.

The key boundary is now explicit:
- users can describe mock NVIDIA inventory once in a ConfigMap and target nodes by label
- `mock-device-plugin` reads that inventory on its refresh loop
- when a matched node has valid inventory, the plugin rewrites `hami.io/node-nvidia-register` from that inventory so the ConfigMap view and the scheduler-facing annotation stay consistent
- when inventory is inactive for a node, the legacy annotation path still works as fallback

This keeps the operational experience much lighter than hand-editing per-node annotation JSON, while avoiding a second source of truth between the ConfigMap and the annotation HAMi already consumes.

## Notes for reviewers
- matched invalid group config fails fast for the current node
- unmatched invalid groups do not block fallback nodes
- valid inventory now rewrites `hami.io/node-nvidia-register` so ConfigMap and annotation do not drift apart
- the legacy annotation-based path remains available as compatibility fallback when inventory is inactive

## Testing
- `git diff --check`
- `go test ./internal/pkg/api/device/...`
- `go test ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mock NVIDIA GPU inventory support via a YAML file, resolved using node labels.
  * Inventory-backed device topology can now sync registered device information into node annotations.
  * Added a CLI flag and updated the Kubernetes mock-plugin manifest to mount the inventory file.

* **Bug Fixes**
  * Malformed/unreadable mock inventory is surfaced as errors (no silent fallback).
  * Clarified and improved fallback behavior between inventory-backed vs legacy annotation modes.

* **Documentation**
  * Updated README with detailed setup, examples, resource calculation rules, and sync/visibility lag.

* **Tests**
  * Expanded unit tests for inventory loading/resolution, NVIDIA device behavior, and flag parsing.

* **Chores**
  * Updated Go toolchain version in CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->